### PR TITLE
[PR] Testing Vercel Preview Deployments Interaction with Github Pages Branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Host on a frontend webhost of your choice. In this case I'm using Github Pages a
 
 - For Github Pages, see the `.github/workflows/gh-pages.yaml` file
 - For Vercel, I just used the default settings (output directory in `build`)
-  - For some reason, the `gh-pages` branch (the branch for actual deployment onto Github Pages) also triggers Vercel Preview deployments.
-    - Please ignore this, the "failed" preview deployment for `gh-pages` branch doesn't mean anything. Due to how I configured the github actions workflow file, by the time `gh-pages` branch has deployed, the app is production ready and preview deployments are redundant.
+  - For some reason, the `gh-pages` branch (the branch for actual deployment onto Github Pages) also triggers Vercel Preview deployments
+    - Please ignore this, the "failed" preview deployment for `gh-pages` branch doesn't mean anything. Due to how I configured the github actions workflow file, by the time `gh-pages` branch has deployed, the app is production ready and preview deployments are redundant
     - See: https://github.com/solderq35/solderq35.github.io/pull/13

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Host on a frontend webhost of your choice. In this case I'm using Github Pages a
 - For Vercel, I just used the default settings (output directory in `build`)
   - For some reason, the `gh-pages` branch (the branch for actual deployment onto Github Pages) also triggers Vercel Preview deployments
     - Please ignore this, the "failed" preview deployment for `gh-pages` branch doesn't mean anything. Due to how I configured the github actions workflow file, by the time `gh-pages` branch has deployed, the app is production ready and preview deployments are redundant
-    - See: https://github.com/solderq35/solderq35.github.io/pull/13
+    - See: https://github.com/solderq35/solderq35.github.io/pull/13 and https://github.com/solderq35/solderq35.github.io/pull/15


### PR DESCRIPTION
EDIT

As I suspected, there is no option to only do Vercel preview builds when you pull request to `main` branch (or if there is a way I haven't found it yet).

- [Option to turn off all preview builds](https://stackoverflow.com/questions/68232548/how-can-i-stop-vercel-preview-deployments-from-appearing-on-pull-requests)
  - This isn't what I want though, this turns off previews for *all* branches when I only wanted to disable preview deployments for gh-pages branch

![image](https://github.com/solderq35/solderq35.github.io/assets/82061589/3fdf74a6-0544-49cc-b09d-7a631d24f6fb)

How it looks like on Vercel:

![image](https://github.com/solderq35/solderq35.github.io/assets/82061589/e68a887d-e85c-48bd-8aa1-62e6d7a05e28)

I *could* just redeploy the preview deployment manually, but it's not worth the trouble. 

Ultimately, I think I would prefer preview deployments on each branch push, to test new feature PR's.

By definition, any changes to `gh-pages` branch are already production ready, so a "failed preview deployment" doesn't mean anything on the gh-pages branch, it's just annoying / bad UI I guess, but I'll ignore it.

I will turn the preview deployments back on for Vercel. 

The whole point of this was just to make sure my portfolio isn't blocked by the company VPN (see https://github.com/solderq35/solderq35.github.io/pull/13), so if I really wanted to, I would buy a custom domain (that isn't blocked by company) and then have Vercel deploy to that, and remove the github pages.

Probably will do that in the future.

Still don't know why the company blocks vercel.app domain but like github.io or railway.app etc, but it is what it is.
